### PR TITLE
T58 "monitor firewall name <name>" does not monitor any firewall-log-entry

### DIFF
--- a/templates/monitor/firewall/name/node.tag/node.def
+++ b/templates/monitor/firewall/name/node.tag/node.def
@@ -3,4 +3,4 @@ allowed: local -a ARR
          eval "ARR=($(cli-shell-api -- listEffectiveNodes firewall name))"
          echo ${ARR[@]}
 run: echo "Notice: monitoring information is displayed only for rules with enabled logging"; \
-     ${vyatta_bindir}/vyatta-monitor Firewall-$4 "\[$4-[0-9]*-[A,D,R]\]"
+     ${vyatta_bindir}/vyatta-monitor Firewall-$4 "\[$4-([0-9]*|default)-[A,D,R]\]"


### PR DESCRIPTION
related to set firewall name <text> enable-default-log
