### PR TITLE
Correctly identify ttyS1 as a serial console, as well (issue T146).

### DIFF
--- a/scripts/vyatta-boot-image.pl
+++ b/scripts/vyatta-boot-image.pl
@@ -102,7 +102,7 @@ sub parseGrubCfg {
 		    # old install
 		    $ehash{'ver'} = $OLD_IMG_VER_STR;
 		}
-		if (/console=tty0.*console=ttyS[01]/) {
+		if (/console=tty0.*console=ttyS[0-9]/) {
 		    $ehash{'term'} = 'serial';
 		} else {
 		    $ehash{'term'} = 'kvm';

--- a/scripts/vyatta-boot-image.pl
+++ b/scripts/vyatta-boot-image.pl
@@ -102,7 +102,7 @@ sub parseGrubCfg {
 		    # old install
 		    $ehash{'ver'} = $OLD_IMG_VER_STR;
 		}
-		if (/console=tty0.*console=ttyS0/) {
+		if (/console=tty0.*console=ttyS[01]/) {
 		    $ehash{'term'} = 'serial';
 		} else {
 		    $ehash{'term'} = 'kvm';


### PR DESCRIPTION
Some devices have the serial console on ttyS1. This change considers `console=ttyS1` to be a valid serial console string, as well as `console=ttyS0` when looking for similar system images.
