### PR TITLE
T1499: Allow for usage of systemd interface mappings

### DIFF
--- a/scripts/vyatta-identify-interface.pl
+++ b/scripts/vyatta-identify-interface.pl
@@ -26,7 +26,7 @@ use strict;
 
 my $intf = shift;
 
-if (!($intf =~ /^eth\d+/)) {
+if (!($intf =~ /^(eth\d+|en[ospx])/)) {
   print STDERR "This command only supports Ethernet interfaces\n";
   exit 1;
 }

--- a/scripts/vyatta-show-interfaces
+++ b/scripts/vyatta-show-interfaces
@@ -22,7 +22,7 @@ shopt -s extglob
 shopt -s nullglob
 
 declare progname=${0##*/}
-declare -a full_itfs=( /sys/class/net/+(eth|vmnet|lo|tun|wan|pppoe|pppoa|adsl)* )
+declare -a full_itfs=( /sys/class/net/+(eno|ens|enp|enx|eth|vmnet|lo|tun|wan|pppoe|pppoa|adsl)* )
 declare -a itfs
 declare _do_show=_show_itf_stats
 
@@ -128,7 +128,7 @@ _usage ()
 _add_itfs ()
 {
     for itf ; do
-	if [[ $itf != +(eth|vmnet|lo|tun|wan|pppoe|pppoa|adsl)* ]] ; then
+	if [[ $itf != +(eno|ens|enp|enx|eth|vmnet|lo|tun|wan|pppoe|pppoa|adsl)* ]] ; then
 	    _error 2 \""$itf"\" is not an interface name\!
 	elif [ ! -d /sys/class/net/$itf ] ; then
 	    _error 2 $itf: no such interface\!
@@ -146,7 +146,7 @@ if [ $# -gt 0 ] ; then
 	if [ $# -eq 1 ] ; then
 	    case $1 in
 		ethernet )
-		    full_itfs=( /sys/class/net/+(eth|vmnet)* ) ;;
+		    full_itfs=( /sys/class/net/+(eno|ens|enp|enx|eth|vmnet)* ) ;;
 		loopback )
 		    full_itfs=( /sys/class/net/lo* ) ;;
 		tunnel )

--- a/templates/clear/interfaces/ethernet/node.tag/node.def
+++ b/templates/clear/interfaces/ethernet/node.tag/node.def
@@ -1,4 +1,4 @@
 help: Clear interface information for a given ethernet interface
 allowed: local -a array ;
-	 array=( /sys/class/net/eth* ) ;
+	 array=( /sys/class/net/eth* /sys/class/net/en* ) ;
 	 echo  -n ${array[@]##*/}

--- a/templates/show/dhcp/client/leases/interface/node.tag/node.def
+++ b/templates/show/dhcp/client/leases/interface/node.tag/node.def
@@ -1,5 +1,5 @@
 help: Show DHCP client information for interface
 allowed: local -a array ;
-         array=( /sys/class/net/eth* ) ;
+         array=( /sys/class/net/eth* /sys/class/net/en* ) ;
          echo  -n ${array[@]##*/}
 run: /opt/vyatta/bin/vyatta-show-dhclient.pl "$6"


### PR DESCRIPTION
This PR allows the use of systemd named interfaces for ethernet.
this might get used when migrating over to buster with systemd default mappings. 