### PR TITLE
[ping] T1450 Recovering ping for ipv6

### DIFF
--- a/scripts/ping
+++ b/scripts/ping
@@ -238,7 +238,7 @@ given ($ip->version) {
     }
 }
 
-my @cmdargs = ( 'ping' );
+my @cmdargs = ( $cmd );
 my $args = [ 'ping', $host, @ARGV ];
 $args = expand_args(\%options, $args);
 shift @$args; shift @$args;


### PR DESCRIPTION
After adding sudo, always runs `ping` instead using `ping6` for ipv6