### PR TITLE
[monitoring] T832: Fix show monitoring

### DIFF
--- a/templates/show/monitoring/node.def
+++ b/templates/show/monitoring/node.def
@@ -1,12 +1,2 @@
 help: Show currently monitored services
-run: echo "------------------------------"
-     echo "Background monitoring sessions"
-     echo "------------------------------"
-     ${vyatta_bindir}/vyatta-monitor-list
-     echo
-     echo "------------------------------"
-     echo "  Protocol monitoring status"
-     echo "------------------------------"
-     for proto in bgp ospf rip ospfv3 ripng; do 
-       show monitoring protocols $proto
-     done
+run: vtysh -c "show debugging"

--- a/templates/show/monitoring/protocols/bgp/node.def
+++ b/templates/show/monitoring/protocols/bgp/node.def
@@ -1,2 +1,0 @@
-help: Show Border Gateway Protocol (BGP) debugging flags
-run: vtysh -c "show debugging bgp"

--- a/templates/show/monitoring/protocols/node.def
+++ b/templates/show/monitoring/protocols/node.def
@@ -1,2 +1,0 @@
-help: Show route protocol debugging flags
-

--- a/templates/show/monitoring/protocols/ospf/node.def
+++ b/templates/show/monitoring/protocols/ospf/node.def
@@ -1,2 +1,0 @@
-help: Show Open Shortest Path First (OSPF) protocol debugging flags
-run: vtysh -c "show debugging ospf"

--- a/templates/show/monitoring/protocols/ospfv3/node.def
+++ b/templates/show/monitoring/protocols/ospfv3/node.def
@@ -1,2 +1,0 @@
-help: Show IPv6 Open Shortest Path First (OSPFv3) protocol debugging flags
-run: vtysh -c "show debugging ospf6"

--- a/templates/show/monitoring/protocols/rib/node.def
+++ b/templates/show/monitoring/protocols/rib/node.def
@@ -1,2 +1,0 @@
-help: Show Routing Information Base (RIB) debugging flags
-run: vtysh -c "show debugging zebra"

--- a/templates/show/monitoring/protocols/rip/node.def
+++ b/templates/show/monitoring/protocols/rip/node.def
@@ -1,2 +1,0 @@
-help: Show Routing Information Protocol (RIP) debugging flags
-run: vtysh -c "show debugging rip"

--- a/templates/show/monitoring/protocols/ripng/node.def
+++ b/templates/show/monitoring/protocols/ripng/node.def
@@ -1,7 +1,0 @@
-help: Show RIPNG protocol debugging flags
-run: if [ ! -e "/usr/sbin/zebra" ]
-     then
-         vtysh -c "show debugging ipv6 rip"
-     else
-         vtysh -c "show debugging ripng"
-     fi


### PR DESCRIPTION
Delete old templates, which not supported in current version on the FRR.
deleted: templates/show/monitoring/protocols/
Fix command "show monitoring" 