### PR TITLE
Monitor vpn ipsec:T3387: The operational command "monitor vpn ipsec" is not working

### DIFF
--- a/templates/monitor/vpn/all/node.def
+++ b/templates/monitor/vpn/all/node.def
@@ -1,3 +1,3 @@
 help: Monitor VPN 
-run: ${vyatta_bindir}/vyatta-monitor 'VPN-ALL' pluto pptp l2tp ppp
+run: ${vyatta_bindir}/vyatta-monitor 'VPN-ALL' pluto ipsec charon pptp l2tp ppp
 

--- a/templates/monitor/vpn/ipsec/node.def
+++ b/templates/monitor/vpn/ipsec/node.def
@@ -1,2 +1,2 @@
 help: Monitor IPSec VPN 
-run: ${vyatta_bindir}/vyatta-monitor "VPN-IPSEC" pluto pptp l2tp ppp
+run: ${vyatta_bindir}/vyatta-monitor "VPN-IPSEC" ipsec charon


### PR DESCRIPTION


	 Changes are made in the script files
         vyatta-op/templates/monitor/vpn/all/node.def
         and vyatta-op/templates/monitor/vpn/ipsec/node.def to change the
         matching parameters to filter the ipsec related logs from the
         /var/log/messages file.


