### PR TITLE
op-mode clear: interfaces dummy: T3623

### DIFF
--- a/templates/clear/interfaces/dummy/node.tag/node.def
+++ b/templates/clear/interfaces/dummy/node.tag/node.def
@@ -1,4 +1,4 @@
 help: Clear interface information for a given dummy interface
 allowed: local -a array ;
-	 array=( /sys/class/net/dummy* ) ;
+	 array=( /sys/class/net/dum* ) ;
 	 echo  -n ${array[@]##*/}


### PR DESCRIPTION
Fixed the completion help for the operational command "clear interfaces dummy"
where it was not showing the list of the dumN interfaces