### PR TITLE
T3950: Use friendly_download instead of regular download

### DIFF
--- a/scripts/vyatta-image-tools.pl
+++ b/scripts/vyatta-image-tools.pl
@@ -126,7 +126,7 @@ sub url_copy {
                 }
             }
         }
-        download($from, $to);
+        friendly_download($from, $to);
     }
     exit 0;
 }
@@ -214,6 +214,11 @@ sub upload {
 sub download {
     my ($from, $to) = @_;
     system("python3 -c 'from vyos.remote import download; download(\"$to\", \"$from\")'");
+}
+
+sub friendly_download {
+    my ($from, $to) = @_;
+    system("python3 -c 'from vyos.remote import friendly_download; friendly_download(\"$to\", \"$from\")'");
 }
 
 sub y_or_n {


### PR DESCRIPTION
Images should be downloaded with `friendly_download()` so that the file isn't the downloaded without sufficient storage space, the user can see a progress bar, and errors are curtailed, 