### PR TITLE
Generate tech-support: T4377: Fix for excluding previous tech-support …

### DIFF
--- a/scripts/tech-support-archive
+++ b/scripts/tech-support-archive
@@ -51,7 +51,7 @@ fi
 
 builtin cd "$OUT"
 echo "Saving the archives..."
-sudo tar zcf config.tgz /opt/vyatta/etc/config --exclude "*tech-support-archive*" >& /dev/null
+sudo tar --exclude "*tech-support-archive*" zcf config.tgz /opt/vyatta/etc/config >& /dev/null
 sudo tar zcf etc.tgz /etc >& /dev/null
 sudo tar zcf home.tgz /home >& /dev/null
 sudo tar zcf var-log.tgz /var/log >& /dev/null


### PR DESCRIPTION


Fix for excluding previous tech-support files, problem that leads to big tech-support file.

How to test. Before patch, generating various tech-support archive generates new file, every-time increasing size as exposed on [T4177](https://phabricator.vyos.net/T4377)
After applying patch:
```
vyos@vyos:~$ ls -la /opt/vyatta/etc/config/support/
total 8
drwxrwsr-x 2 root vyattacfg 4096 Apr 29 10:26 .
drwxrwsr-x 7 root vyattacfg 4096 Apr 29 10:13 ..
vyos@vyos:~$ generate tech-support archive 
Saving the archives...
Saved tech-support archival at /opt/vyatta/etc/config/support/vyos.tech-support-archive.2022-04-29-102713.tgz
vyos@vyos:~$ generate tech-support archive 
Saving the archives...
Saved tech-support archival at /opt/vyatta/etc/config/support/vyos.tech-support-archive.2022-04-29-102727.tgz
vyos@vyos:~$ generate tech-support archive 
Saving the archives...
Saved tech-support archival at /opt/vyatta/etc/config/support/vyos.tech-support-archive.2022-04-29-102732.tgz
vyos@vyos:~$ du -h /opt/vyatta/etc/config/support/*
1.5M	/opt/vyatta/etc/config/support/vyos.tech-support-archive.2022-04-29-102713.tgz
1.5M	/opt/vyatta/etc/config/support/vyos.tech-support-archive.2022-04-29-102727.tgz
1.5M	/opt/vyatta/etc/config/support/vyos.tech-support-archive.2022-04-29-102732.tgz
vyos@vyos:~$ 

```