### PR TITLE
tech-support-archive: T4377: Exclude saving archives to a new archive.

### DIFF
--- a/scripts/tech-support-archive
+++ b/scripts/tech-support-archive
@@ -51,7 +51,7 @@ fi
 
 builtin cd "$OUT"
 echo "Saving the archives..."
-sudo tar zcf config.tgz /opt/vyatta/etc/config --exclude "*tech-support-archive*" >& /dev/null
+sudo tar --exclude "*tech-support-archive*" zcf config.tgz /opt/vyatta/etc/config  >& /dev/null
 sudo tar zcf etc.tgz /etc >& /dev/null
 sudo tar zcf home.tgz /home >& /dev/null
 sudo tar zcf var-log.tgz /var/log >& /dev/null


### PR DESCRIPTION
> ## Change Summary
> Fix generate tech-support archive includes previous archives
> 
> ## Types of changes
> * [x]  Bug fix (non-breaking change which fixes an issue)
> * [ ]  New feature (non-breaking change which adds functionality)
> * [ ]  Code style update (formatting, renaming)
> * [ ]  Refactoring (no functional changes)
> * [ ]  Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
> * [ ]  Other (please describe):
> 
> ## Related Task(s)
> * https://phabricator.vyos.net/T4377
> 
> ## Component(s) name
> generate tech-support archive
> 
> ## Proposed changes
> ## How to test
> Generate five version of tech-support archive:
> 
> ```
> $ generate tech-support archive
> $ generate tech-support archive
> $ generate tech-support archive
> $ generate tech-support archive
> $ generate tech-support archive

> ```
> 
> The expected result of each archive does not include the previous one:
> 
> ```
> 
> 
> ```
> 
> ## Checklist:
> * [x]  I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
> * [x]  I have linked this PR to one or more Phabricator Task(s)
> * [ ]  I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
> * [ ]  My commit headlines contain a valid Task id
> * [ ]  My change requires a change to the documentation
> * [ ]  I have updated the documentation accordingly