### PR TITLE
images management: T4113: Improved GRUB config parsing

### DIFF
--- a/scripts/vyatta-boot-image.pl
+++ b/scripts/vyatta-boot-image.pl
@@ -102,7 +102,7 @@ sub parseGrubCfg {
 		    # old install
 		    $ehash{'ver'} = $OLD_IMG_VER_STR;
 		}
-		if (/console=tty0.*console=ttyS[0-9]/) {
+		if (/console=ttyS\d(?!.*console)/) {
 		    $ehash{'term'} = 'serial';
 		} else {
 		    $ehash{'term'} = 'kvm';
@@ -170,7 +170,7 @@ sub deleteGrubEntries {
         @entry = ();
       } else {
 	  if (/^\s+linux/) {
-	      if (/^\s+linux \/boot\/([^\/ ]+)\/.* boot=live /) {
+	      if (/^\s+linux \/boot\/([^\/ ]+)\/.* boot=live/) {
 		  # kernel line
 		  $ver = $1;
 	      } else {


### PR DESCRIPTION
Backported fix of wrong GRUB config parser, that helps to resolve issues:

* items with only one `console=ttyS0` were wrongly detected as those that have a `kvm` console type
* items where the `boot=live`option is the latest one cannot be removed from a configuration during an image removal