### PR TITLE
op-mode: T4606: Fix monitor nat src|dst translation

### DIFF
--- a/templates/monitor/nat/destination/translations/node.def
+++ b/templates/monitor/nat/destination/translations/node.def
@@ -1,4 +1,4 @@
 help: Monitor active destination NAT translations events
 run: LESSOPEN=cat
      echo Type control-C to quit 
-     sudo /usr/sbin/conntrack -E -g -o xml 2>/dev/null | ${vyatta_bindir}/sudo-users/vyatta-nat-translations.pl --pipe --type=destination
+     sudo /usr/sbin/conntrack --dst-nat --event

--- a/templates/monitor/nat/source/translations/node.def
+++ b/templates/monitor/nat/source/translations/node.def
@@ -1,4 +1,4 @@
 help: Monitor active source NAT translations events
 run: LESSOPEN=cat
-     echo Type control-C to quit 
-     sudo /usr/sbin/conntrack -E -n -o xml 2>/dev/null | ${vyatta_bindir}/sudo-users/vyatta-nat-translations.pl --pipe --type=source
+     echo Type control-C to quit
+     sudo /usr/sbin/conntrack --src-nat --event


### PR DESCRIPTION
A quick fix for "monitor nat source|destination translations"
Due to the old Perl script `vyatta-nat-translations.pl` was deleted and
to return it requires an additional Perl package (`XML::Simple module`)
There is no sense in doing it until we'll rewrite it to Python
So a compromise solution is to show conntrack events `conntrack` itself

https://phabricator.vyos.net/T4606

before fix:
```

vyos@r14:~$ monitor nat source translations 
Type control-C to quit
-vbash: /opt/vyatta/bin/sudo-users/vyatta-nat-translations.pl: No such file or directory
vyos@r14:~$ 

vyos@r14:~$ monitor nat destination translations 
Type control-C to quit
-vbash: /opt/vyatta/bin/sudo-users/vyatta-nat-translations.pl: No such file or directory

^Cvyos@r14:~$
```
after Fix:
```
vyos@r14:~$ monitor nat source translations | strip-private
Type control-C to quit
    [NEW] udp      17 30 src=xxx.xxx.2.2 dst=xxx.xxx.1.1 sport=33236 dport=53 [UNREPLIED] src=xxx.xxx.1.1 dst=xxx.xxx.122.14 sport=53 dport=33236
 [UPDATE] udp      17 86400 src=xxx.xxx.2.2 dst=xxx.xxx.1.1 sport=33236 dport=53 src=xxx.xxx.1.1 dst=xxx.xxx.122.14 sport=53 dport=33236 [OFFLOAD]
    [NEW] udp      17 30 src=xxx.xxx.2.2 dst=xxx.xxx.1.1 sport=36265 dport=53 [UNREPLIED] src=xxx.xxx.1.1 dst=xxx.xxx.122.14 sport=53 dport=36265
 [UPDATE] udp      17 86400 src=xxx.xxx.2.2 dst=xxx.xxx.1.1 sport=36265 dport=53 src=xxx.xxx.1.1 dst=xxx.xxx.122.14 sport=53 dport=36265 [OFFLOAD]
    [NEW] udp      17 30 src=xxx.xxx.2.2 dst=xxx.xxx.1.1 sport=38321 dport=53 [UNREPLIED] src=xxx.xxx.1.1 dst=xxx.xxx.122.14 sport=53 dport=38321
 [UPDATE] udp      17 86400 src=xxx.xxx.2.2 dst=xxx.xxx.1.1 sport=38321 dport=53 src=xxx.xxx.1.1 dst=xxx.xxx.122.14 sport=53 dport=38321 [OFFLOAD]
    [NEW] udp      17 30 src=xxx.xxx.2.2 dst=xxx.xxx.1.1 sport=51034 dport=53 [UNREPLIED] src=xxx.xxx.1.1 dst=xxx.xxx.122.14 sport=53 dport=51034
 [UPDATE] udp      17 86400 src=xxx.xxx.2.2 dst=xxx.xxx.1.1 sport=51034 dport=53 src=xxx.xxx.1.1 dst=xxx.xxx.122.14 sport=53 dport=51034 [OFFLOAD]
    [NEW] udp      17 30 src=xxx.xxx.2.2 dst=xxx.xxx.1.1 sport=41124 dport=53 [UNREPLIED] src=xxx.xxx.1.1 dst=xxx.xxx.122.14 sport=53 dport=41124
 [UPDATE] udp      17 86400 src=xxx.xxx.2.2 dst=xxx.xxx.1.1 sport=41124 dport=53 src=xxx.xxx.1.1 dst=xxx.xxx.122.14 sport=53 dport=41124 [OFFLOAD]
    [NEW] udp      17 30 src=xxx.xxx.2.2 dst=xxx.xxx.1.1 sport=41262 dport=53 [UNREPLIED] src=xxx.xxx.1.1 dst=xxx.xxx.122.14 sport=53 dport=41262
 [UPDATE] udp      17 86400 src=xxx.xxx.2.2 dst=xxx.xxx.1.1 sport=41262 dport=53 src=xxx.xxx.1.1 dst=xxx.xxx.122.14 sport=53 dport=41262 [OFFLOAD]
^Cconntrack v1.4.6 (conntrack-tools): 12 flow events have been shown.

```