### PR TITLE
interfaces: T5130: remove show/interfaces/node.def, defined in vyos-1x

### DIFF
--- a/templates/show/interfaces/node.def
+++ b/templates/show/interfaces/node.def
@@ -1,2 +1,0 @@
-help: Show network interface information
-run: ${vyos_op_scripts_dir}/show_interfaces.py --action=show-brief


### PR DESCRIPTION
Remove node.def in favor of definition in vyos-1x.

This is replaced by:
https://github.com/vyos/vyos-1x/pull/1923