### PR TITLE
T5457: Add environmental variable pointing to current rootfs directory

### DIFF
--- a/etc/default/vyatta.in
+++ b/etc/default/vyatta.in
@@ -168,12 +168,17 @@ unset _vyatta_extglob
         declare -x -r vyos_op_scripts_dir=$vyos_libexec_dir/op_mode
     fi
 
-    if test -z "$vyos_completion__dir" ; then
+    if test -z "$vyos_completion_dir" ; then
         declare -x -r vyos_completion_dir=$vyos_libexec_dir/completion
     fi
 
     if test -z "$vyos_validators_dir" ; then
         declare -x -r vyos_validators_dir=$vyos_libexec_dir/validators
+    fi
+
+    if test -z "$vyos_rootfs_dir" ; then
+        ROOTFS=$(mount -t squashfs | cut -d' ' -f3)
+        declare -x -r vyos_rootfs_dir="${ROOTFS}"
     fi
 
     if test -z "$VRF" ; then


### PR DESCRIPTION
## Change Summary
This adds a new environmental variable named "vyos_rootfs_dir" (to be used for scripting and such) which points to the path which the /dev/loop0 is mounted as (the squashfs from the iso).

## Related Task(s)
Fixes:
https://vyos.dev/T5457

Also partly fixes:
https://vyos.dev/T5440

Bonus: Also fixes the check for variable $vyos_completion_dir had a typo (there were two underscores instead of just one).

## How to test:
After boot do a "export | grep -i rootfs" and the output should be similar to:

```
vyos@vyos:~$ export | grep -i rootfs
declare -rx vyos_rootfs_dir="/usr/lib/live/mount/rootfs/1.4-rolling-202308060317.squashfs"
```

which matches the mount of loop0:

```
vyos@vyos:~$ mount | grep -i loop0
/dev/loop0 on /usr/lib/live/mount/rootfs/1.4-rolling-202308060317.squashfs type squashfs (ro,noatime,errors=continue)
```

and the fileaccess such as:

```
vyos@vyos:~$ ls -la /usr/lib/live/mount/rootfs/1.4-rolling-202308060317.squashfs/opt/vyatta/etc/config/scripts/
total 1
drwxrwsr-x 2 root vyattacfg  88 Aug  6 05:17 .
drwxrwsr-x 6 root vyattacfg  74 Aug  6 05:17 ..
-rwxr-xr-x 1 root vyattacfg 230 Aug  6 05:17 vyos-postconfig-bootup.script
-rwxr-xr-x 1 root vyattacfg 225 Aug  6 05:17 vyos-preconfig-bootup.script
```

along with:

```
vyos@vyos:~$ ls -la ${vyos_rootfs_dir}/opt/vyatta/etc/config/scripts/
total 1
drwxrwsr-x 2 root vyattacfg  88 Aug  6 05:17 .
drwxrwsr-x 6 root vyattacfg  74 Aug  6 05:17 ..
-rwxr-xr-x 1 root vyattacfg 230 Aug  6 05:17 vyos-postconfig-bootup.script
-rwxr-xr-x 1 root vyattacfg 225 Aug  6 05:17 vyos-preconfig-bootup.script
```