### PR TITLE
T5461: Improve rootfs directory variable

### DIFF
--- a/etc/default/vyatta.in
+++ b/etc/default/vyatta.in
@@ -177,8 +177,8 @@ unset _vyatta_extglob
     fi
 
     if test -z "$vyos_rootfs_dir" ; then
-        ROOTFS=$(mount -t squashfs | cut -d' ' -f3)
-        declare -x -r vyos_rootfs_dir="${ROOTFS}"
+        IMAGE_NAME=$(cat /proc/cmdline | sed -e s+^.*vyos-union=/boot/++ | sed -e 's/ .*$//')
+        declare -x -r vyos_rootfs_dir="/usr/lib/live/mount/rootfs/${IMAGE_NAME}.squashfs"
     fi
 
     if test -z "$VRF" ; then


### PR DESCRIPTION
## Change Summary
Commit made by https://vyos.dev/T5457 can be improved to avoid risk of selecting the wrong partition/path.

The method used by /src/init/vyos-router (variable image_name) is safer and will also use cmdline as source instead of mount.

## Related Task(s)
https://vyos.dev/T5461

## How to test:
Compare the output of (should read /usr/lib/live/mount/rootfs/...):

```
root@vyos:/home/vyos# mount -t squashfs | cut -d' ' -f3
/usr/lib/live/mount/rootfs/1.4-rolling-202308060317.squashfs
```

with the output of:

```
root@vyos:/home/vyos# echo ${vyos_rootfs_dir}
/usr/lib/live/mount/rootfs/1.4-rolling-202308060317.squashfs
```