### PR TITLE
T5690: change to definition of environment variable 'vyos_rootfs_dir' is incorrect

### DIFF
--- a/etc/default/vyatta.in
+++ b/etc/default/vyatta.in
@@ -177,8 +177,8 @@ unset _vyatta_extglob
     fi
 
     if test -z "$vyos_rootfs_dir" ; then
-        IMAGE_NAME=$(cat /proc/cmdline | sed -e s+^.*vyos-union=/boot/++ | sed -e 's/ .*$//')
-        declare -x -r vyos_rootfs_dir="/usr/lib/live/mount/rootfs/${IMAGE_NAME}.squashfs"
+        ROOTFS=$(mount -t squashfs | cut -d' ' -f3)
+        declare -x -r vyos_rootfs_dir="${ROOTFS}"
     fi
 
     if test -z "$VRF" ; then


### PR DESCRIPTION
This reverts commit 6b03f6864063bc0ab95191b8c5e418d482baf076.

As explained in the task, the original definition by the author is correct (for its current use; cf. discussion in task); the revision is not. Added as a PR for easy backport to Sagitta.